### PR TITLE
Propagate original error in RuntimeError.cause

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,7 @@
-export function RuntimeError(message, input) {
+export function RuntimeError(message, input, cause = undefined) {
   this.message = message + "";
   this.input = input;
+  this.cause = cause;
 }
 
 RuntimeError.prototype = Object.create(Error.prototype);

--- a/src/variable.js
+++ b/src/variable.js
@@ -58,7 +58,7 @@ function variable_undefined() {
 function variable_rejector(variable) {
   return function(error) {
     if (error === variable_undefined) throw new RuntimeError(variable._name + " is not defined", variable._name);
-    if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name, {cause: error});
+    if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name, cause: error);
     throw new RuntimeError(variable._name + " could not be resolved", variable._name);
   };
 }

--- a/src/variable.js
+++ b/src/variable.js
@@ -58,7 +58,7 @@ function variable_undefined() {
 function variable_rejector(variable) {
   return function(error) {
     if (error === variable_undefined) throw new RuntimeError(variable._name + " is not defined", variable._name);
-    if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name, cause: error);
+    if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name, error);
     throw new RuntimeError(variable._name + " could not be resolved", variable._name);
   };
 }

--- a/src/variable.js
+++ b/src/variable.js
@@ -58,7 +58,7 @@ function variable_undefined() {
 function variable_rejector(variable) {
   return function(error) {
     if (error === variable_undefined) throw new RuntimeError(variable._name + " is not defined", variable._name);
-    if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name);
+    if (error instanceof Error && error.message) throw new RuntimeError(error.message, variable._name, {cause: error});
     throw new RuntimeError(variable._name + " could not be resolved", variable._name);
   };
 }


### PR DESCRIPTION
Currently, if variable `A` value function throws custom subclass of `Error`, that custom subclass is lost when the error is converted to `RuntimeError`, and is subsequently unavailable in the custom inspector. This PR puts the original error in RuntimeError.cause, thereby making it available to custom inspectors. Behavior of default inspector is unchanged. 